### PR TITLE
修正低版本浏览支持的 indexOf, forEach, trim 的断言

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,8 +41,8 @@ if (typeof window !== 'undefined') {
     };
   }
   if (!Array.prototype.forEach) {
-    Array.prototype.forEach = function (fn) {
-      for (var i = 0; i < this.length; i++) fn(this[i], i, this);
+    Array.prototype.forEach = function (fn, scope) {
+      for (var i = 0; i < this.length; i++) fn.call(scope, this[i], i, this);
     };
   }
   if(!String.prototype.trim){


### PR DESCRIPTION
chrome 没有实现 Array 的静态方法 `forEach`, 但确实实现了 ES5 `Array.prototype.forEach`

我在 angular 项目使用此 xxs, 由于 `forEach` 被覆盖, 但没有提供第二个参数 `context` 导致 angular 使用 `Array.prototype.forEach` 解析抛错.
