### PR TITLE
避免窜改 Array.prototype

### DIFF
--- a/lib/default.js
+++ b/lib/default.js
@@ -4,6 +4,7 @@
  * @author 老雷<leizongmin@gmail.com>
  */
 
+var _ = require('./util');
 
 // 默认白名单
 var whiteList = {
@@ -144,7 +145,7 @@ function safeAttrValue (tag, name, value) {
   if (name === 'href' || name === 'src') {
     // 过滤 href 和 src 属性
     // 仅允许 http:// | https:// | mailto: | / 开头的地址
-    value = value.trim();
+    value = _.trim(value);
     if (value === '#') return '#';
     if (!(value.substr(0, 7) === 'http://' ||
          value.substr(0, 8) === 'https://' ||
@@ -256,7 +257,7 @@ function clearNonPrintableCharacter (str) {
   for (var i = 0, len = str.length; i < len; i++) {
     str2 += str.charCodeAt(i) < 32 ? ' ' : str.charAt(i);
   }
-  return str2.trim();
+  return _.trim(str2);
 }
 
 /**
@@ -306,7 +307,7 @@ function StripTagBody (tags, next) {
   var isRemoveAllTag = !Array.isArray(tags);
   function isRemoveTag (tag) {
     if (isRemoveAllTag) return true;
-    return (tags.indexOf(tag) !== -1);
+    return (_.indexOf(tags, tag) !== -1);
   }
 
   var removeList = [];   // 要删除的位置范围列表
@@ -334,7 +335,7 @@ function StripTagBody (tags, next) {
     remove: function (html) {
       var rethtml = '';
       var lastPos = 0;
-      removeList.forEach(function (pos) {
+      _.forEach(removeList, function (pos) {
         rethtml += html.slice(lastPos, pos[0]);
         lastPos = pos[1];
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,28 +29,6 @@ for (var i in DEFAULT) exports[i] = DEFAULT[i];
 for (var i in parser) exports[i] = parser[i];
 
 
-// 低版本浏览器支持
-if (!Array.prototype.indexOf) {
-  Array.prototype.indexOf = function (item) {
-    for (var i = 0; i < this.length; i++) {
-      if (this[i] === item) return i;
-    }
-    return -1;
-  };
-}
-if (!Array.prototype.forEach) {
-  Array.prototype.forEach = function (fn, scope) {
-    for (var i = 0; i < this.length; i++) {
-      fn.call(scope, this[i], i, this);
-    }
-  };
-}
-if (!String.prototype.trim) {
-  String.prototype.trim = function () {
-    return this.replace(/(^\s*)|(\s*$)/g, '');
-  };
-}
-
 
 // 在AMD下使用
 if (typeof define === 'function' && define.amd) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4,6 +4,7 @@
  * @author 老雷<leizongmin@gmail.com>
  */
 
+var _ = require('./util');
 
 /**
  * 获取标签的名称
@@ -18,7 +19,7 @@ function getTagName (html) {
   } else {
     var tagName = html.slice(1, i + 1);
   }
-  tagName = tagName.trim().toLowerCase();
+  tagName = _.trim(tagName).toLowerCase();
   if (tagName[0] === '/') tagName = tagName.slice(1);
   if (tagName[tagName.length - 1] === '/') tagName = tagName.slice(0, -1);
   return tagName;
@@ -123,7 +124,7 @@ function parseAttr (html, onAttr) {
   var len = html.length;  // HTML代码长度
 
   function addAttr (name, value) {
-    name =  name.trim();
+    name = _.trim(name);
     name = name.replace(REGEXP_ATTR_NAME, '').toLowerCase();
     if (name.length < 1) return;
     retAttrs.push(onAttr(name, value || ''));
@@ -143,7 +144,7 @@ function parseAttr (html, onAttr) {
         if (j === -1) {
           break;
         } else {
-          v = html.slice(lastPos + 1, j).trim();
+          v = _.trim(html.slice(lastPos + 1, j));
           addAttr(tmpName, v);
           tmpName = false;
           i = j;
@@ -153,7 +154,7 @@ function parseAttr (html, onAttr) {
       }
     }
     if (c === ' ') {
-      v = html.slice(lastPos, i).trim();
+      v = _.trim(html.slice(lastPos, i));
       if (tmpName === false) {
         addAttr(v);
       } else {
@@ -173,7 +174,7 @@ function parseAttr (html, onAttr) {
     }
   }
 
-  return retAttrs.join(' ').trim();
+  return _.trim(retAttrs.join(' '));
 }
 
 exports.parseTag = parseTag;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,29 @@
+module.exports = {
+  indexOf: function (arr, item) {
+    var i, j;
+    if (Array.prototype.indexOf) {
+      return arr.indexOf(item);
+    }
+    for (i = 0, j = arr.length; i < j; i++) {
+      if (arr[i] === item) {
+        return i;
+      }
+    }
+    return -1;
+  },
+  forEach: function (arr, fn, scope) {
+    var i, j;
+    if (Array.prototype.forEach) {
+      return arr.forEach(fn, scope);
+    }
+    for (i = 0, j = arr.length; i < j; i++) {
+      fn.call(scope, arr[i], i, arr);
+    }
+  },
+  trim: function (str) {
+    if (String.prototype.forEach) {
+      return str.trim();
+    }
+    return str.replace(/(^\s*)|(\s*$)/g, '');
+  }
+};

--- a/lib/xss.js
+++ b/lib/xss.js
@@ -8,6 +8,7 @@ var DEFAULT = require('./default');
 var parser = require('./parser');
 var parseTag = parser.parseTag;
 var parseAttr = parser.parseAttr;
+var _ = require('./util');
 
 
 /**
@@ -36,9 +37,9 @@ function getAttrs (html) {
       closing: (html[html.length - 2] === '/')
     };
   }
-  html = html.slice(i + 1, -1).trim();
+  html = _.trim(html.slice(i + 1, -1));
   var isClosing = (html[html.length - 1] === '/');
-  if (isClosing) html = html.slice(0, -1).trim();
+  if (isClosing) html = _.trim(html.slice(0, -1));
   return {
     html:    html,
     closing: isClosing
@@ -137,7 +138,7 @@ FilterXSS.prototype.process = function (html) {
       var attrsHtml = parseAttr(attrs.html, function (name, value) {
 
         // 调用onTagAttr处理
-        var isWhiteAttr = (whiteAttrList.indexOf(name) !== -1);
+        var isWhiteAttr = (_.indexOf(whiteAttrList, name) !== -1);
         var ret = onTagAttr(tag, name, value, isWhiteAttr);
         if (!isNull(ret)) return ret;
 


### PR DESCRIPTION
目前的项目代码在做 for 回圈时都没有用 hasOwnProperty 检查、且 js-xss 对旧浏览器在 Array.prototype 加上 indexOf 及 forEach 两个方法，导致我们突然产生许多问题。

由于函式库可能会被用在各种不同的环境，是否有可能采用风险最低、不窜改 Array.prototype 的作法呢？

## Avoid pollution of global Array

```
However, extending Array.prototype comes with the price; And that price is chance of collisions. When scripts coexist with other scripts in an application, it’s important for those scripts not to conflict with each other. Extending Array.prototype, while tempting and seemingly useful, unfortunately isn’t very safe in a diverse environment. Different scripts can end up defining same-named methods, but with different behavior. Such scenario often leads to inconsistent behavior and hard-to-track errors.
```
[原文网址](http://perfectionkills.com/how-ecmascript-5-still-does-not-allow-to-subclass-an-array/#avoid_pollution_of_global_array)
