### PR TITLE
Update parser.js

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -20,8 +20,8 @@ function getTagName (html) {
     var tagName = html.slice(1, i + 1);
   }
   tagName = _.trim(tagName).toLowerCase();
-  if (tagName[0] === '/') tagName = tagName.slice(1);
-  if (tagName[tagName.length - 1] === '/') tagName = tagName.slice(0, -1);
+  if (tagName.slice(0, 1) === '/') tagName = tagName.slice(1);
+  if (tagName.slice(-1) === '/') tagName = tagName.slice(0, -1);
   return tagName;
 }
 


### PR DESCRIPTION
IE7中不支持string[index]的用法改用slice做兼容