### PR TITLE
parseAttr 对特殊 html 进行支持（例如 word 复制的 html 内容）

### DIFF
--- a/dist/xss.js
+++ b/dist/xss.js
@@ -607,7 +607,7 @@ function parseAttr (html, onAttr) {
         }
       }
     }
-    if (c === ' ') {
+    if (/\s|\n/.test(c)) {
       if (tmpName === false) {
         j = findNextEqual(html, i);
         if (j === -1) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -157,7 +157,7 @@ function parseAttr (html, onAttr) {
         }
       }
     }
-    if (c === ' ') {
+    if (/\s|\n/.test(c)) {
       if (tmpName === false) {
         j = findNextEqual(html, i);
         if (j === -1) {


### PR DESCRIPTION
对特殊 html 进行支持（例如 word 复制的 html 内容）

如果只通过 空格进行区分，就会出现以下问题：
```
<img width=100 height=200
src='....'/>
```

这种没有空格，只有换行的 html 转换后会变为

```
<img width="100" height="200 src=&quot;....&quot;“/>
```