### PR TITLE
Fix 'DedicatedWorkerGlobalScope is not defined' error on Web env

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ if (typeof window !== "undefined") {
 
 // using `xss` on the WebWorker, output `filterXSS` to the globals
 function isWorkerEnv() {
-  return typeof self !== 'undefined' && self instanceof DedicatedWorkerGlobalScope;
+  return typeof self !== 'undefined' && typeof DedicatedWorkerGlobalScope !== 'undefined' && self instanceof DedicatedWorkerGlobalScope;
 }
 if (isWorkerEnv()) {
   self.filterXSS = module.exports;


### PR DESCRIPTION
This fixes code added in https://github.com/leizongmin/js-xss/commit/723b307a32541044e4f4dcbb260c34b3168e87f2 which causes #140 

I didn't commit built version because that'd could be a chance for me to put nasty code in the minified file without anybody noticing :) .