### PR TITLE
Consider allowCommentTag when parsing tags

### DIFF
--- a/lib/xss.js
+++ b/lib/xss.js
@@ -190,6 +190,8 @@ FilterXSS.prototype.process = function(html) {
         if (attrs.closing) html += " /";
         html += ">";
         return html;
+      } else if (options.allowCommentTag && tag.startsWith('!--')) {
+        return html;
       } else {
         // call `onIgnoreTag()`
         var ret = onIgnoreTag(tag, html, info);


### PR DESCRIPTION
Currently, the `allowCommentTag` option is not enough to preserve comments when used together with `stripIgnoreTag` or `stripIgnoreTagBody`. The following code can be used to reproduce the issue:

```
<script src="https://rawgit.com/leizongmin/js-xss/master/dist/xss.js"></script>
<script>
var html = filterXSS(
    '<span><!-- a comment --></span>',
    {
        allowCommentTag: true,
        stripIgnoreTagBody: true,
    }
);
alert(html);
</script>
```
This code, when ran in the browser, yields the value:

`<span>[removed]</span>`

While using `stripIgnoreTag`, it outputs:

`<span></span>`

The proposed fix is to consider the `allowCommentTag` when deciding whether to remove or preserve a tag.