### PR TITLE
Allow default imports in TS

### DIFF
--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strictNullChecks": true,
     "noImplicitAny": true,
-    "module": "commonjs"
+    "module": "commonjs",
+    "esModuleInterop": true
   }
 }

--- a/typings/xss-default-import.ts
+++ b/typings/xss-default-import.ts
@@ -1,0 +1,5 @@
+/// <reference path="./xss.d.ts" />
+
+import xss from "xss";
+
+console.log(xss("<script>alert('xss');</script>"));

--- a/typings/xss.d.ts
+++ b/typings/xss.d.ts
@@ -4,186 +4,190 @@
  * @author Zongmin Lei<leizongmin@gmail.com>
  */
 
-declare global {
-  function filterXSS(html: string, options?: IFilterXSSOptions): string;
+declare module "xss" {
+  global {
+    function filterXSS(html: string, options?: IFilterXSSOptions): string;
 
-  namespace XSS {
-    export interface IFilterXSSOptions {
-      whiteList?: IWhiteList;
-      onTag?: OnTagHandler;
-      onTagAttr?: OnTagAttrHandler;
-      onIgnoreTag?: OnTagHandler;
-      onIgnoreTagAttr?: OnTagAttrHandler;
-      safeAttrValue?: SafeAttrValueHandler;
-      escapeHtml?: EscapeHandler;
-      stripIgnoreTag?: boolean;
-      stripIgnoreTagBody?: boolean | string[];
-      allowCommentTag?: boolean;
-      stripBlankChar?: boolean;
-      css?: {} | boolean;
-    }
+    namespace XSS {
+      export interface IFilterXSSOptions {
+        whiteList?: IWhiteList;
+        onTag?: OnTagHandler;
+        onTagAttr?: OnTagAttrHandler;
+        onIgnoreTag?: OnTagHandler;
+        onIgnoreTagAttr?: OnTagAttrHandler;
+        safeAttrValue?: SafeAttrValueHandler;
+        escapeHtml?: EscapeHandler;
+        stripIgnoreTag?: boolean;
+        stripIgnoreTagBody?: boolean | string[];
+        allowCommentTag?: boolean;
+        stripBlankChar?: boolean;
+        css?: {} | boolean;
+      }
 
-    interface IWhiteList {
-      a?: string[];
-      abbr?: string[];
-      address?: string[];
-      area?: string[];
-      article?: string[];
-      aside?: string[];
-      audio?: string[];
-      b?: string[];
-      bdi?: string[];
-      bdo?: string[];
-      big?: string[];
-      blockquote?: string[];
-      br?: string[];
-      caption?: string[];
-      center?: string[];
-      cite?: string[];
-      code?: string[];
-      col?: string[];
-      colgroup?: string[];
-      dd?: string[];
-      del?: string[];
-      details?: string[];
-      div?: string[];
-      dl?: string[];
-      dt?: string[];
-      em?: string[];
-      font?: string[];
-      footer?: string[];
-      h1?: string[];
-      h2?: string[];
-      h3?: string[];
-      h4?: string[];
-      h5?: string[];
-      h6?: string[];
-      header?: string[];
-      hr?: string[];
-      i?: string[];
-      img?: string[];
-      ins?: string[];
-      li?: string[];
-      mark?: string[];
-      nav?: string[];
-      ol?: string[];
-      p?: string[];
-      pre?: string[];
-      s?: string[];
-      section?: string[];
-      small?: string[];
-      span?: string[];
-      sub?: string[];
-      sup?: string[];
-      strong?: string[];
-      table?: string[];
-      tbody?: string[];
-      td?: string[];
-      tfoot?: string[];
-      th?: string[];
-      thead?: string[];
-      tr?: string[];
-      tt?: string[];
-      u?: string[];
-      ul?: string[];
-      video?: string[];
-    }
+      interface IWhiteList {
+        a?: string[];
+        abbr?: string[];
+        address?: string[];
+        area?: string[];
+        article?: string[];
+        aside?: string[];
+        audio?: string[];
+        b?: string[];
+        bdi?: string[];
+        bdo?: string[];
+        big?: string[];
+        blockquote?: string[];
+        br?: string[];
+        caption?: string[];
+        center?: string[];
+        cite?: string[];
+        code?: string[];
+        col?: string[];
+        colgroup?: string[];
+        dd?: string[];
+        del?: string[];
+        details?: string[];
+        div?: string[];
+        dl?: string[];
+        dt?: string[];
+        em?: string[];
+        font?: string[];
+        footer?: string[];
+        h1?: string[];
+        h2?: string[];
+        h3?: string[];
+        h4?: string[];
+        h5?: string[];
+        h6?: string[];
+        header?: string[];
+        hr?: string[];
+        i?: string[];
+        img?: string[];
+        ins?: string[];
+        li?: string[];
+        mark?: string[];
+        nav?: string[];
+        ol?: string[];
+        p?: string[];
+        pre?: string[];
+        s?: string[];
+        section?: string[];
+        small?: string[];
+        span?: string[];
+        sub?: string[];
+        sup?: string[];
+        strong?: string[];
+        table?: string[];
+        tbody?: string[];
+        td?: string[];
+        tfoot?: string[];
+        th?: string[];
+        thead?: string[];
+        tr?: string[];
+        tt?: string[];
+        u?: string[];
+        ul?: string[];
+        video?: string[];
+      }
 
-    type OnTagHandler = (
-      tag: string,
-      html: string,
-      options: {}
-    ) => string | void;
+      type OnTagHandler = (
+        tag: string,
+        html: string,
+        options: {}
+      ) => string | void;
 
-    type OnTagAttrHandler = (
-      tag: string,
-      name: string,
-      value: string,
-      isWhiteAttr: boolean
-    ) => string | void;
+      type OnTagAttrHandler = (
+        tag: string,
+        name: string,
+        value: string,
+        isWhiteAttr: boolean
+      ) => string | void;
 
-    type SafeAttrValueHandler = (
-      tag: string,
-      name: string,
-      value: string,
-      cssFilter: ICSSFilter
-    ) => string;
+      type SafeAttrValueHandler = (
+        tag: string,
+        name: string,
+        value: string,
+        cssFilter: ICSSFilter
+      ) => string;
 
-    type EscapeHandler = (str: string) => string;
+      type EscapeHandler = (str: string) => string;
 
-    interface ICSSFilter {
-      process(value: string): string;
+      interface ICSSFilter {
+        process(value: string): string;
+      }
     }
   }
-}
+  export interface IFilterXSSOptions extends XSS.IFilterXSSOptions {}
 
-export interface IFilterXSSOptions extends XSS.IFilterXSSOptions {}
+  export interface IWhiteList extends XSS.IWhiteList {}
 
-export interface IWhiteList extends XSS.IWhiteList {}
+  export type OnTagHandler = XSS.OnTagHandler;
 
-export type OnTagHandler = XSS.OnTagHandler;
+  export type OnTagAttrHandler = XSS.OnTagAttrHandler;
 
-export type OnTagAttrHandler = XSS.OnTagAttrHandler;
+  export type SafeAttrValueHandler = XSS.SafeAttrValueHandler;
 
-export type SafeAttrValueHandler = XSS.SafeAttrValueHandler;
+  export type EscapeHandler = XSS.EscapeHandler;
 
-export type EscapeHandler = XSS.EscapeHandler;
+  export interface ICSSFilter extends XSS.ICSSFilter {}
 
-export interface ICSSFilter extends XSS.ICSSFilter {}
+  export function StripTagBody(
+    tags: string[],
+    next: () => void
+  ): {
+    onIgnoreTag(
+      tag: string,
+      html: string,
+      options: {
+        position: number;
+        isClosing: boolean;
+      }
+    ): string;
+    remove(html: string): string;
+  };
 
-export function StripTagBody(
-  tags: string[],
-  next: () => void
-): {
-  onIgnoreTag(
-    tag: string,
+  export class FilterXSS {
+    constructor(options?: IFilterXSSOptions);
+    process(html: string): string;
+  }
+
+  export function filterXSS(html: string, options?: IFilterXSSOptions): string;
+  export function parseTag(
     html: string,
-    options: {
-      position: number;
-      isClosing: boolean;
-    }
+    onTag: (
+      sourcePosition: number,
+      position: number,
+      tag: string,
+      html: string,
+      isClosing: boolean
+    ) => string,
+    escapeHtml: EscapeHandler
   ): string;
-  remove(html: string): string;
-};
-
-export class FilterXSS {
-  constructor(options?: IFilterXSSOptions);
-  process(html: string): string;
-}
-
-export function filterXSS(html: string, options?: IFilterXSSOptions): string;
-export function parseTag(
-  html: string,
-  onTag: (
-    sourcePosition: number,
-    position: number,
-    tag: string,
+  export function parseAttr(
     html: string,
-    isClosing: boolean
-  ) => string,
-  escapeHtml: EscapeHandler
-): string;
-export function parseAttr(
-  html: string,
-  onAttr: (name: string, value: string) => string
-): string;
-export const whiteList: IWhiteList;
-export function getDefaultWhiteList(): IWhiteList;
-export const onTag: OnTagHandler;
-export const onIgnoreTag: OnTagHandler;
-export const onTagAttr: OnTagAttrHandler;
-export const onIgnoreTagAttr: OnTagAttrHandler;
-export const safeAttrValue: SafeAttrValueHandler;
-export const escapeHtml: EscapeHandler;
-export const escapeQuote: EscapeHandler;
-export const unescapeQuote: EscapeHandler;
-export const escapeHtmlEntities: EscapeHandler;
-export const escapeDangerHtml5Entities: EscapeHandler;
-export const clearNonPrintableCharacter: EscapeHandler;
-export const friendlyAttrValue: EscapeHandler;
-export const escapeAttrValue: EscapeHandler;
-export function onIgnoreTagStripAll(): string;
-export const stripCommentTag: EscapeHandler;
-export const stripBlankChar: EscapeHandler;
-export const cssFilter: ICSSFilter;
-export function getDefaultCSSWhiteList(): ICSSFilter;
+    onAttr: (name: string, value: string) => string
+  ): string;
+  export const whiteList: IWhiteList;
+  export function getDefaultWhiteList(): IWhiteList;
+  export const onTag: OnTagHandler;
+  export const onIgnoreTag: OnTagHandler;
+  export const onTagAttr: OnTagAttrHandler;
+  export const onIgnoreTagAttr: OnTagAttrHandler;
+  export const safeAttrValue: SafeAttrValueHandler;
+  export const escapeHtml: EscapeHandler;
+  export const escapeQuote: EscapeHandler;
+  export const unescapeQuote: EscapeHandler;
+  export const escapeHtmlEntities: EscapeHandler;
+  export const escapeDangerHtml5Entities: EscapeHandler;
+  export const clearNonPrintableCharacter: EscapeHandler;
+  export const friendlyAttrValue: EscapeHandler;
+  export const escapeAttrValue: EscapeHandler;
+  export function onIgnoreTagStripAll(): string;
+  export const stripCommentTag: EscapeHandler;
+  export const stripBlankChar: EscapeHandler;
+  export const cssFilter: ICSSFilter;
+  export function getDefaultCSSWhiteList(): ICSSFilter;
+
+  const xss: (html: string, options?: IFilterXSSOptions) => string;
+  export default xss;
+}


### PR DESCRIPTION
This makes the ES6 version of the example on the homepage work:

```ts
import xss from "xss";
const html = xss('<script>alert("xss");</script>');
console.log(html);
```

Note that this only works if `esModuleInterop` is set to `true`, which is officially recommended (`tsc init` produces a `tsconfig.json` file with it set). You can read more about it [here](https://stackoverflow.com/questions/56238356/understanding-esmoduleinterop-in-tsconfig-file).

The existing type tests seemed to be broken before this PR:

```
$ npm install typescript
$ tsc --version
Version 3.9.7
$ tsc --noEmit -p typings/tsconfig.json
typings/xss-tests.ts:9:22 - error TS2307: Cannot find module 'xss' or its corresponding type declarations.

9 import * as xss from "xss";
                       ~~~~~

typings/xss-tests.ts:30:14 - error TS7006: Parameter 'str' implicitly has an 'any' type.

30   escapeHtml(str) {
                ~~~

typings/xss-tests.ts:34:9 - error TS7006: Parameter 'tag' implicitly has an 'any' type.

34   onTag(tag, html, options) {
           ~~~

typings/xss-tests.ts:34:14 - error TS7006: Parameter 'html' implicitly has an 'any' type.

34   onTag(tag, html, options) {
                ~~~~

typings/xss-tests.ts:34:20 - error TS7006: Parameter 'options' implicitly has an 'any' type.

34   onTag(tag, html, options) {
                      ~~~~~~~

typings/xss-tests.ts:37:15 - error TS7006: Parameter 'tag' implicitly has an 'any' type.

37   onIgnoreTag(tag, html) {}
                 ~~~

typings/xss-tests.ts:37:20 - error TS7006: Parameter 'html' implicitly has an 'any' type.

37   onIgnoreTag(tag, html) {}
                      ~~~~


Found 7 errors.
```

After it they are not:

```
$ tsc -p typings/tsconfig.json
```