### PR TITLE
docs: Fix simple typo, doube -> double

### DIFF
--- a/dist/xss.js
+++ b/dist/xss.js
@@ -218,7 +218,7 @@ var REGEXP_DEFAULT_ON_TAG_ATTR_7 = /e\s*x\s*p\s*r\s*e\s*s\s*s\s*i\s*o\s*n\s*\(.*
 var REGEXP_DEFAULT_ON_TAG_ATTR_8 = /u\s*r\s*l\s*\(.*/gi;
 
 /**
- * escape doube quote
+ * escape double quote
  *
  * @param {String} str
  * @return {String} str

--- a/lib/default.js
+++ b/lib/default.js
@@ -217,7 +217,7 @@ var REGEXP_DEFAULT_ON_TAG_ATTR_7 = /e\s*x\s*p\s*r\s*e\s*s\s*s\s*i\s*o\s*n\s*\(.*
 var REGEXP_DEFAULT_ON_TAG_ATTR_8 = /u\s*r\s*l\s*\(.*/gi;
 
 /**
- * escape doube quote
+ * escape double quote
  *
  * @param {String} str
  * @return {String} str


### PR DESCRIPTION
There is a small typo in dist/xss.js, lib/default.js.

Should read `double` rather than `doube`.

