### PR TITLE
Add `<summary>` to default whitelist

### DIFF
--- a/dist/xss.js
+++ b/dist/xss.js
@@ -61,6 +61,7 @@ function getDefaultWhiteList() {
     small: [],
     span: [],
     sub: [],
+    summary: [],
     sup: [],
     strong: [],
     table: ["width", "border", "align", "valign"],


### PR DESCRIPTION
Since `<details>` is in there, it makes sense for `<summary>` as well since that is used inside `<details>` to define the text label/title for the collapsible element.

See example: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details