### PR TITLE
Add <figure> and <figcaption> to default whitelist

### DIFF
--- a/lib/default.js
+++ b/lib/default.js
@@ -36,6 +36,8 @@ function getDefaultWhiteList() {
     dl: [],
     dt: [],
     em: [],
+    figcaption: [],
+    figure: [],
     font: ["color", "size", "face"],
     footer: [],
     h1: [],


### PR DESCRIPTION
* Figure https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
* Figcaption https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption

Most RSS feeds are using these tags to wrap around media content. I propose to add these tags to the default whitelist because they don't require any attribute and do not open any XSS vulnerability