### PR TITLE
docs: correct empty whiteList typing in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ img1, img2, img3, img4
 ```javascript
 var source = "<strong>hello</strong><script>alert(/xss/);</script>end";
 var html = xss(source, {
-  whiteList: [], // empty, means filter out all tags
+  whiteList: {}, // empty, means filter out all tags
   stripIgnoreTag: true, // filter out all HTML not in the whitelist
   stripIgnoreTagBody: ["script"] // the script tag is a special case, we need
   // to filter out its content

--- a/README.zh.md
+++ b/README.zh.md
@@ -442,7 +442,7 @@ img1, img2, img3, img4
 ```javascript
 var source = "<strong>hello</strong><script>alert(/xss/);</script>end";
 var html = xss(source, {
-  whiteList: [], // 白名单为空，表示过滤所有标签
+  whiteList: {}, // 白名单为空，表示过滤所有标签
   stripIgnoreTag: true, // 过滤所有非白名单标签的HTML
   stripIgnoreTagBody: ["script"] // script标签较特殊，需要过滤标签中间的内容
 });

--- a/example/strip_tag.js
+++ b/example/strip_tag.js
@@ -8,7 +8,7 @@ var xss = require('../');
 
 var source = '<strong>hello</strong><script>alert(/xss/);</script>end';
 var html = xss(source, {
-  whiteList:          [],        // 白名单为空，表示过滤所有标签
+  whiteList:          {},        // 白名单为空，表示过滤所有标签
   stripIgnoreTag:     true,      // 过滤所有非白名单标签的HTML
   stripIgnoreTagBody: ['script'] // script标签较特殊，需要过滤标签中间的内容
 });


### PR DESCRIPTION
The `whiteList` config is defined as an object map actually, and its typing is described [here](https://github.com/leizongmin/js-xss/blob/master/typings/xss.d.ts#L27). But some of the examples in README file use it as an empty array. So if someone copied the example codes directly, they might be curious why the type checkings fails. 

This PR simply corrects these usages in docs, please have a look :)