### PR TITLE
fix: add `allowList` to types

### DIFF
--- a/typings/xss.d.ts
+++ b/typings/xss.d.ts
@@ -10,6 +10,7 @@ declare module "xss" {
 
     namespace XSS {
       export interface IFilterXSSOptions {
+        allowList?: IWhiteList;
         whiteList?: IWhiteList;
         onTag?: OnTagHandler;
         onTagAttr?: OnTagAttrHandler;


### PR DESCRIPTION
#249 added `allowList` as an alias to `whiteList`. However, it's absent from `IFilterXSSOptions`.

This PR adds the `allowList` property to the TypeScript definitions.