### PR TITLE
feat: Allow loading attribute on img

### DIFF
--- a/lib/default.js
+++ b/lib/default.js
@@ -57,7 +57,7 @@ function getDefaultWhiteList() {
     header: [],
     hr: [],
     i: [],
-    img: ["src", "alt", "title", "width", "height"],
+    img: ["src", "alt", "title", "width", "height", "loading"],
     ins: ["datetime"],
     li: [],
     mark: [],

--- a/test/test_xss.js
+++ b/test/test_xss.js
@@ -133,6 +133,12 @@ describe("test XSS", function() {
       ),
       '<img width="100" height="200" title="xxx" alt="\'yyy\'">'
     );
+    assert.equal(
+      xss(
+        '<img loading="lazy">'
+      ),
+      '<img loading="lazy">'
+    );
 
     // 使用Tab或换行符分隔的属性
     assert.equal(


### PR DESCRIPTION
Hello,
thanks too from me for this library!

This PR allows loading attribute on imgelement, which is now considered standard in modern browsers: https://caniuse.com/loading-lazy-attr

I came across this, as this xss library is used in [Grafana](https://github.com/grafana/grafana/blob/main/packages/grafana-data/package.json).