### PR TITLE
feat: add <kbd> to default whitelist

### DIFF
--- a/lib/default.js
+++ b/lib/default.js
@@ -59,6 +59,7 @@ function getDefaultWhiteList() {
     i: [],
     img: ["src", "alt", "title", "width", "height"],
     ins: ["datetime"],
+    kbd: [],
     li: [],
     mark: [],
     nav: [],


### PR DESCRIPTION
Hello! First of all, thanks for this good library :) 

Like `<code>`, `<blockquote>`, `<h1>` tags, `<kbd>` tag is also used in WYSIWYG editor.
So, I added `<kbd>` tag to default whitelist. Please check!

* https://developer.mozilla.org/ko/docs/Web/HTML/Element/kbd