### PR TITLE
feat: single-quoted attribute value syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,20 @@ function safeAttrValue(tag, name, value) {
 }
 ```
 
+### Customize output attribute value syntax for HTML
+
+By specifying a `singleQuotedAttributeValue`. Use `true` for `'`. Otherwise default `"` will be used
+
+```javascript
+var options = {
+  singleQuotedAttributeValue: true,
+};
+// With the configuration specified above, the following HTML:
+// <a href="#">Hello</a>
+// would become:
+// <a href='#'>Hello</a>
+```
+
 ### Customize CSS filter
 
 If you allow the attribute `style`, the value will be processed by [cssfilter](https://github.com/leizongmin/js-css-filter) module. The cssfilter module includes a default css whitelist. You can specify the options for cssfilter module like this:

--- a/lib/default.js
+++ b/lib/default.js
@@ -455,5 +455,6 @@ exports.onIgnoreTagStripAll = onIgnoreTagStripAll;
 exports.StripTagBody = StripTagBody;
 exports.stripCommentTag = stripCommentTag;
 exports.stripBlankChar = stripBlankChar;
+exports.attributeWrapSign = '"';
 exports.cssFilter = defaultCSSFilter;
 exports.getDefaultCSSWhiteList = getDefaultCSSWhiteList;

--- a/lib/xss.js
+++ b/lib/xss.js
@@ -100,6 +100,8 @@ function FilterXSS(options) {
     options.whiteList = DEFAULT.whiteList;
   }
 
+  this.attributeWrapSign = options.singleQuotedAttributeValue === true ? "'" : DEFAULT.attributeWrapSign;
+
   options.onTag = options.onTag || DEFAULT.onTag;
   options.onTagAttr = options.onTagAttr || DEFAULT.onTagAttr;
   options.onIgnoreTag = options.onIgnoreTag || DEFAULT.onIgnoreTag;
@@ -137,6 +139,7 @@ FilterXSS.prototype.process = function (html) {
   var onIgnoreTagAttr = options.onIgnoreTagAttr;
   var safeAttrValue = options.safeAttrValue;
   var escapeHtml = options.escapeHtml;
+  var attributeWrapSign = me.attributeWrapSign;
   var cssFilter = me.cssFilter;
 
   // remove invisible characters
@@ -190,7 +193,7 @@ FilterXSS.prototype.process = function (html) {
             // call `safeAttrValue()`
             value = safeAttrValue(tag, name, value, cssFilter);
             if (value) {
-              return name + '="' + value + '"';
+              return name + '=' + attributeWrapSign + value + attributeWrapSign;
             } else {
               return name;
             }

--- a/test/test_xss.js
+++ b/test/test_xss.js
@@ -428,6 +428,22 @@ describe("test XSS", function() {
     );
   });
 
+  it("#singleQuotedAttributeValue", function() {
+    assert.equal(xss('<a title="xx">not-defined</a>'), '<a title="xx">not-defined</a>');
+    assert.equal(
+      xss('<a title="xx">single-quoted</a>', { singleQuotedAttributeValue: true }),
+      '<a title=\'xx\'>single-quoted</a>'
+    );
+    assert.equal(
+      xss('<a title="xx">double-quoted</a>', { singleQuotedAttributeValue: false }),
+      '<a title="xx">double-quoted</a>'
+    );
+    assert.equal(
+      xss('<a title="xx">invalid-value</a>', { singleQuotedAttributeValue: 'invalid' }),
+      '<a title="xx">invalid-value</a>'
+    );
+  })
+
   it("no options mutated", function() {
     var options = {};
 

--- a/typings/xss.d.ts
+++ b/typings/xss.d.ts
@@ -22,6 +22,7 @@ declare module "xss" {
         stripIgnoreTagBody?: boolean | string[];
         allowCommentTag?: boolean;
         stripBlankChar?: boolean;
+        singleQuotedAttributeValue?: boolean;
         css?: {} | boolean;
       }
 
@@ -195,6 +196,7 @@ declare module "xss" {
   export function onIgnoreTagStripAll(): string;
   export const stripCommentTag: EscapeHandler;
   export const stripBlankChar: EscapeHandler;
+  export const attributeWrapSign: string;
   export const cssFilter: ICSSFilter;
   export function getDefaultCSSWhiteList(): ICSSFilter;
 


### PR DESCRIPTION
Hi @leizongmin!

First of all thank you for creating this package. We have been using it for sanitizing html and put it inside JSON files. It can be done in two ways:

- `{ "html": "<a href=\"#\">Hello</a>" }`
- `{ "html": "<a href='#'>Hello</a>" }`

but the default config output is:
- `{ "html": "<a href="#">Hello</a>" }`

We would like to use default config and don't create any custom rules via `safeAttrValue` or `onIgnoreTagAttr`, but we need to have single-quoted attribute value syntax for sanitized output. Accodring to [whatwg spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2), single quoted approach is also valid and supports values containing whitespaces.

I've created a PR. Now it's available use new `quotedAttributeValueSyntax` config option. Default behaviour left intact so changes can be treated as enhancement.

Let me know what you think