### PR TITLE
fix: avoid O(n^2) whitespace normalization in parseAttr

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -129,6 +129,10 @@ function parseAttr(html, onAttr) {
   var lastMarkPos = 0;
   var retAttrs = [];
   var tmpName = false;
+  // Normalize all whitespace once, up front. Previously this replace ran
+  // inside the loop on every whitespace character, rescanning the whole
+  // string each time -> O(n^2) on attribute-heavy input (CWE-407 DoS).
+  html = html.replace(/\s|\n|\t/g, " ");
   var len = html.length;
 
   function addAttr(name, value) {
@@ -167,7 +171,6 @@ function parseAttr(html, onAttr) {
       }
     }
     if (/\s|\n|\t/.test(c)) {
-      html = html.replace(/\s|\n|\t/g, " ");
       if (tmpName === false) {
         j = findNextEqual(html, i);
         if (j === -1) {


### PR DESCRIPTION
### Summary

`parseAttr()` re-runs a full-string whitespace normalization on **every**
whitespace character it encounters, rescanning the entire attribute string each
time. For a tag with N whitespace-separated attribute tokens this is
N × O(N) = **O(n²)**, so attribute-heavy input makes `xss()` quadratic.

Because the input to an HTML sanitizer is untrusted by definition, this is a
CPU-exhaustion / DoS vector (CWE-407 Inefficient Algorithmic Complexity): a
single moderately sized field can block the event loop for seconds.

Measured on the current code, input `'<a ' + 'x=1 '.repeat(n) + '>'`:

| attributes | input size | before  | after  |
|-----------:|-----------:|--------:|-------:|
|      2,000 |       8 KB |  185 ms |  ~2 ms |
|      8,000 |      32 KB | 2762 ms |  ~5 ms |
|     16,000 |      64 KB |   ~11 s | ~13 ms |

### Fix

The normalization `html = html.replace(/\s|\n|\t/g, " ")` is idempotent and
length-preserving, so it only needs to run **once, before** the loop rather than
on every whitespace character inside it. This removes the O(n²) while producing
byte-for-byte identical output.

### Verification

- The existing test suite passes unchanged (`npm test`, 42 passing).
- Differential test over 800+ inputs (structured tags, random fuzz, the attack
  string, and whitespace/quote edge cases): output is **identical** before and
  after the change.
- Timing is now linear (see table).

### Notes

Found and fixed with AI assistance (Claude). Happy to tweak the comment or add a
regression test to the suite if you'd like.
